### PR TITLE
feat: context7 MCP で AI が最新ライブラリ仕様を参照できる

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,5 +84,6 @@
       "Bash(yarn install:*)",
       "Bash(yarn:*)"
     ]
-  }
+  },
+  "enabledMcpjsonServers": ["context7"]
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -14,6 +14,13 @@
         "/Users/koki/Develop/Next.js_projects/LastMatorix"
       ],
       "env": {}
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@2.1.8"
+      ]
     }
   }
 }


### PR DESCRIPTION
## 概要
context7 MCP サーバーを `.mcp.json` に定義し、`.claude/settings.json` で enable することで、Claude Code が最新ライブラリドキュメント (Next.js / Tailwind 等) を取得できるようにする。学習データカットオフより新しい仕様を扱えるようになり、Phase 2 (依存関係最新化) のバージョンアップ作業の生産性を向上する。

## 関連Issue
close #67

## 変更内容
- [x] `.mcp.json` の `mcpServers` に context7 を追加 (`npx @upstash/context7-mcp@2.1.8`)
- [x] `.claude/settings.json` に `enabledMcpjsonServers: ["context7"]` を追加 (明示リスト方式)

## スクリーンショット（UI変更の場合）
N/A (設定ファイルのみの変更)

## テスト結果
- [x] `jq` で `.mcp.json` の妥当性確認、`.mcpServers.context7.command = "npx"` を検証
- [x] `jq` で `.claude/settings.json` の妥当性確認、`enabledMcpjsonServers` に `"context7"` 含有を検証
- [ ] **手動確認 (マージ後)**: 新セッションで `mcp__context7__*` ツールが呼び出せること
- [ ] **手動確認 (マージ後)**: Next.js 15 `useActionState` API を Claude に尋ね、context7 経由で最新ドキュメント取得を確認

## チェックリスト
- [x] コーディング規約に準拠している
- [ ] 必要なテストを追加した (N/A: 設定ファイルのみ)
- [x] すべてのテストが成功している (既存テストへの影響なし)
- [ ] ドキュメントを更新した（必要な場合） (N/A: 仕様書 `仕様書-Claude-Code活用基盤整備.md` 既存節をそのまま実装した形)
- [x] コンフリクトを解消した

## 備考
- 親 ISSUE: #60 (Claude Code フロントリファクタリング基盤を整える) のサブ
- enable 方式は明示リスト (`enabledMcpjsonServers`) を採用。`enableAllProjectMcpServers: true` は使わず、将来 `.mcp.json` に MCP を追加した際の意図せぬ enable を防ぐ
- `.claude/settings.local.json` の `enableAllProjectMcpServers: true` は個人ローカル設定として既存、本 PR では変更しない