### PR TITLE
#93 CLAUDE.md と .claude/rules/*.md を main に反映する

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,8 @@
+---
+title: Architecture
+description: ディレクトリ構成・コンポーネント設計・関数型・状態管理ルール
+---
+
+# Architecture
+
+(Phase 2 で内容を移植する)

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -5,4 +5,298 @@ description: ディレクトリ構成・コンポーネント設計・関数型�
 
 # Architecture
 
-(Phase 2 で内容を移植する)
+## ディレクトリ構造 — Colocation
+
+ページで使うコンポーネントは、そのページと同階層の `components/` ディレクトリに置く。複数のページから使うものだけ上位に昇格する。
+
+**例外**: `front/lib/` と `front/components/` (リポジトリ共通プリミティブ) は Colocation 対象外。共通ユーティリティ (例: `lib/utils.ts`) と共通 UI プリミティブ (例: `components/ui/button.tsx`) を置く。これらに対して Container/Presenter などのページ層ルールは適用しない。
+
+```
+front/
+├── lib/                       # 共通ユーティリティ (例外)
+│   └── utils.ts
+├── components/                # 共通 UI プリミティブ (例外)
+│   └── ui/
+│       └── button.tsx
+├── features/                  # 機能単位 (Auth / Tasks など)
+│   └── Tasks/
+│       └── ...
+└── app/
+    ├── Home/
+    │   ├── page.tsx
+    │   └── components/
+    │       ├── MatrixArea/
+    │       │   ├── MatrixArea.tsx
+    │       │   └── MatrixArea.container.tsx
+    │       └── TaskCard/
+    │           └── TaskCard.tsx
+    ├── Profile/
+    │   ├── page.tsx
+    │   └── components/
+    │       └── ProfileForm/
+    │           └── ProfileForm.tsx
+    └── components/             # 複数ページから使うもののみ
+        └── Sidebar/
+            └── Sidebar.tsx
+```
+
+## ディレクトリ・ファースト構成
+
+**コンポーネントは day1 から自分のディレクトリを持つ**。最初に `Component.tsx` をフラットに作って、後で子要素が増えたタイミングでディレクトリ化する、という流れを取らない。子コンポーネントが無くてもディレクトリを作ってその中に置く。
+
+**初期状態** — 子コンポーネントなし、でもディレクトリは存在する:
+
+```
+components/
+└── TaskCard/
+    └── TaskCard.tsx              # Presenter (主コンポーネント)
+```
+
+**子コンポーネントが増えたとき** — 同じディレクトリ内の兄弟ファイルとして配置 (`components/` をネストさせない):
+
+```
+components/
+└── TaskCard/
+    ├── TaskCard.tsx              # Presenter
+    ├── TaskCard.container.tsx    # Container
+    └── PriorityBadge.tsx         # 子コンポーネント
+```
+
+子コンポーネントを別ファイルに切り出すタイミング:
+
+- 子コンポーネントが ~30 行を超える
+- 子コンポーネントが独自の props 型を持つ
+- 子コンポーネントが独自のテストファイルを持つ
+
+上記に該当するまでは、`TaskCard.tsx` 内に小さな内部ヘルパーコンポーネントとして置いてもよい (export しない)。
+
+## 1 ファイル 1 コンポーネント
+
+- 各 `.tsx` ファイルは 1 つのコンポーネントだけを export する
+- ファイル名はコンポーネント名と一致させる (`TaskCard.tsx` → `TaskCard`)
+- 内部ヘルパー関数や非公開のサブコンポーネントは OK だが、export してはいけない
+- **`default export` 禁止**。常に名前付き export を使う。
+
+## Container / Presenter パターン
+
+コンポーネントを **Container** と **Presenter** に分割する。
+
+**Presenter** — 純粋な描画コンポーネント。状態を持たず、出力は props だけで決まる。
+
+```tsx
+// TaskCard.tsx (Presenter)
+type TaskCardProps = {
+  title: string;
+  importance: "high" | "low";
+  urgency: "high" | "low";
+  onToggleDone: () => void;
+};
+
+export const TaskCard = ({ title, importance, urgency, onToggleDone }: TaskCardProps) => (
+  <div className={`p-4 rounded-lg ${importance === "high" ? "bg-red-100" : "bg-blue-100"}`}>
+    <h3>{title}</h3>
+    <span>{urgency === "high" ? "急" : "あとで"}</span>
+    <button onClick={onToggleDone}>完了</button>
+  </div>
+);
+```
+
+**Container** — データ取得と状態を担当し、Presenter に props として渡す。
+
+```tsx
+// TaskCard.container.tsx (Container)
+import { TaskCard } from "./TaskCard";
+import { useTask } from "@/hooks/useTask";
+
+type TaskCardContainerProps = { taskId: string };
+
+export const TaskCardContainer = ({ taskId }: TaskCardContainerProps) => {
+  const { data, toggleDone, isLoading } = useTask(taskId);
+  if (isLoading || !data) return null;
+  return (
+    <TaskCard
+      title={data.title}
+      importance={data.importance}
+      urgency={data.urgency}
+      onToggleDone={toggleDone}
+    />
+  );
+};
+```
+
+**命名規約**:
+
+| ファイル | 役割 |
+|---|---|
+| `ComponentName.tsx` | Presenter |
+| `ComponentName.container.tsx` | Container |
+
+## ロジックは純粋関数として抽出
+
+ビジネスロジックや変換処理は、コンポーネントから取り出して純粋関数として書く。
+
+```ts
+// utils.ts
+export const classifyTask = (
+  importance: "high" | "low",
+  urgency: "high" | "low"
+): "do" | "schedule" | "delegate" | "eliminate" => {
+  if (importance === "high" && urgency === "high") return "do";
+  if (importance === "high" && urgency === "low") return "schedule";
+  if (importance === "low" && urgency === "high") return "delegate";
+  return "eliminate";
+};
+```
+
+純粋関数の要件:
+
+- 同じ入力に対して常に同じ出力を返す
+- 副作用を持たない (DOM 操作・API 呼び出し・外部変数の変更を行わない)
+- 外部状態に依存しない
+
+## Props ドリブン設計
+
+コンポーネントは外部から props で制御できなければならない。内部状態に基づいて分岐する設計を避ける。
+
+```tsx
+// NG: 内部状態に閉じている
+const Dialog = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return isOpen ? <div>...</div> : null;
+};
+
+// OK: 外部から制御可能
+type DialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const Dialog = ({ isOpen, onClose }: DialogProps) => {
+  if (!isOpen) return null;
+  return (
+    <div>
+      ...
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+};
+```
+
+オプショナルな props にはデフォルト値を必ず与え、`undefined` の扱いを明確にする。
+
+## 関数型プログラミング原則
+
+### 純粋関数のみ
+
+引数のみに依存し、外部状態を変更しない関数を作る。
+
+```ts
+// NG: 外部の変数に依存
+let minimumAge = 18;
+function isAdult(age: number): boolean {
+  return age >= minimumAge;
+}
+
+// OK: 引数として必要な値をすべて受け取る
+function isAdult(age: number, legalMinimumAge: number): boolean {
+  return age >= legalMinimumAge;
+}
+```
+
+### 変数の再代入禁止
+
+`const` を使い、配列・オブジェクトの更新は新しいインスタンスを返す。
+
+```ts
+// NG: ミュータブルな更新
+const numbers = [1, 2, 3];
+numbers.push(4);
+
+// OK: イミュータブルな更新
+const numbers = [1, 2, 3] as const;
+const newNumbers = [...numbers, 4];
+```
+
+### 早期 return
+
+ガード節でネストを浅く保つ。
+
+```ts
+// NG: 深いネスト
+function getDiscount(userType: string, amount: number): number {
+  if (userType === "premium") {
+    if (amount > 10000) return 0.15;
+    return 0.1;
+  }
+  return amount > 5000 ? 0.05 : 0;
+}
+
+// OK: 早期 return
+function getDiscount(userType: string, amount: number): number {
+  if (userType !== "premium") return amount > 5000 ? 0.05 : 0;
+  if (amount > 10000) return 0.15;
+  return 0.1;
+}
+```
+
+### 副作用の隔離
+
+API 呼び出し・状態変更などの副作用を伴う処理は、専用関数やカスタムフックに切り出す。React コンポーネントでは `useFetch` / `useAnalytics` のようなカスタムフックに集約する。
+
+## 状態管理
+
+### 関連状態の集約
+
+関連する状態は、カスタムフックまたはオブジェクトに集約して再レンダリングを最小化する。
+
+### イミュータブル更新を徹底する
+
+Jotai / Zustand / `useState` / `useReducer` いずれを使う場合も、配列・オブジェクトの更新は **`map` / `filter` / `reduce` / spread (`...`)** を使い、新しい参照を返す。
+
+```tsx
+// Jotai 例 — 書き込み専用 atom でイミュータブル更新
+import { atom } from "jotai";
+
+type Task = { id: string; title: string; isDone: boolean };
+
+export const tasksAtom = atom<Task[]>([]);
+
+export const toggleTaskAtom = atom(null, (get, set, taskId: string) => {
+  set(tasksAtom, prev =>
+    prev.map(task => (task.id === taskId ? { ...task, isDone: !task.isDone } : task))
+  );
+});
+```
+
+```tsx
+// useReducer 例
+type Action =
+  | { type: "add"; payload: Task }
+  | { type: "toggle"; payload: { id: string } };
+
+function reducer(state: Task[], action: Action): Task[] {
+  switch (action.type) {
+    case "add":
+      return [...state, action.payload];
+    case "toggle":
+      return state.map(task =>
+        task.id === action.payload.id ? { ...task, isDone: !task.isDone } : task
+      );
+  }
+}
+```
+
+## 機能単位のディレクトリ分割と定数集約
+
+- **機能単位**で `front/features/<FeatureName>/` を切る (例: `features/Auth/` / `features/Tasks/`)
+- 列挙型・定数は `front/constants/` (または `front/lib/constants.ts`) に集約し、再利用性と型安全性を確保する
+
+```ts
+// constants/task.ts
+export const TASK_STATUS = {
+  Invalid: 0,
+  Valid: 1,
+} as const;
+
+export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
+```

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -5,4 +5,83 @@ description: 依存ライブラリの追加・更新方針
 
 # Dependencies
 
-(Phase 2 で内容を移植する)
+## パッケージマネージャ
+
+`yarn` を使う。`npm` / `pnpm` / `bun` は混在させない。
+
+```bash
+cd front
+yarn install              # 既存依存をインストール
+yarn add <pkg>            # dependencies 追加
+yarn add -D <pkg>         # devDependencies 追加
+yarn list --depth=0       # 直接依存のバージョン確認
+```
+
+## バージョン固定 (Exact Version Pinning)
+
+リファクタ完了までは依存ライブラリの更新を意図的に行うため、`package.json` のバージョンは **完全固定**を原則とする。`^` / `~` / メジャー指定 (`"4"` / `"^20"`) は避け、`"1.2.3"` のように exact version を書く。
+
+**NG**:
+
+```json
+{
+  "dependencies": {
+    "next": "^15.4.6",
+    "react": "19"
+  }
+}
+```
+
+**OK**:
+
+```json
+{
+  "dependencies": {
+    "next": "15.4.6",
+    "react": "19.0.0"
+  }
+}
+```
+
+**追加・更新時の作法**:
+
+- 追加: `yarn add -E <pkg>` / `yarn add -E -D <pkg>` (`-E` で exact 固定)
+- 既存依存の更新後、`package.json` に `^` / `~` / メジャー指定が残っていないかを確認する。残っていたら手動で exact に直す。
+- 現行インストール版を確認するには `yarn list --depth=0` を使う。
+- `package.json` と `yarn.lock` を常に一致させる。
+
+理由: 「どの環境でも同じバージョンが入る」ことを保証することで、リファクタ作業中の差分要因を依存バージョン以外に絞り込みやすくする。
+
+## バージョンアップの進め方
+
+- 大きいバージョンアップ (Next.js / TypeScript / Tailwind / MUI / ESLint 等) は **1 ライブラリ 1 ISSUE** で行う (親 ISSUE 配下のサブ ISSUE)。
+- 仕様書 `仕様書-Claude-Code活用基盤整備.md` の **Phase 2 (依存関係最新化)** ロードマップを参照する。
+- マイナー追従は `yarn upgrade-interactive --latest` でまとめて行ってよいが、PR は機械的更新の旨を明記する。
+- **MUI v5 → v7** は中継 (v6) を挟まず一気に上げる方針 (仕様書 line 23 / line 319 参照)。
+- ESLint v8 → v9 は flat config 化を伴う。
+- **MUI のバージョンアップで v6 を中継してはならない**。同じ箇所を 2 回触るコストが上回るため。
+
+## 主要ライブラリ (現状)
+
+`front/package.json` の主要依存 (バージョンは現行値、Phase 2 で最新化対象):
+
+| 用途 | ライブラリ |
+|---|---|
+| フレームワーク | `next` (App Router) |
+| ビュー | `react` / `react-dom` |
+| UI | `@mui/material` / `@mui/icons-material` / `@emotion/react` / `@emotion/styled` |
+| スタイル | `tailwindcss` / `postcss` / `autoprefixer` |
+| 認証・DB | `firebase` |
+| HTTP | `axios` |
+| DnD | `@dnd-kit/core` / `@dnd-kit/sortable` |
+| 日付 | `react-datepicker` |
+| Lint / Format | `@biomejs/biome` (+ `eslint` は移行期) |
+| テスト | `vitest` / `@vitest/coverage-v8` / `@vitest/ui` / `@testing-library/*` / `jsdom` |
+| ビルド | `vite` (テスト基盤として) |
+| 型 | `typescript` / `@types/react` |
+
+## 環境変数
+
+- 機密情報は `.env.local` (フロント) / `.env` (バックエンド) に置く。**git に commit しない**。
+- フロントから読む変数は `NEXT_PUBLIC_` プレフィックスが必要 (Next.js 仕様)。
+- 値の例は `front/.env.local.example` などに **空値で**コミットする。

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -1,0 +1,8 @@
+---
+title: Dependencies
+description: 依存ライブラリの追加・更新方針
+---
+
+# Dependencies
+
+(Phase 2 で内容を移植する)

--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -5,4 +5,162 @@ description: 命名・コメント・コードスタイル・Tailwind 利用ル�
 
 # Coding Style
 
-(Phase 2 で内容を移植する)
+## 命名
+
+- **完全かつ明示的な識別子**を使用し、省略語を避ける (`userId` / `targetUserIndex` / `paymentMethod` など)。
+- 変数名・関数名は、その役割が一目でわかるように、省略せずに記述する。
+- 名前衝突が起きうる場合のみ、ドメインを示す接頭辞・接尾辞を検討する (過剰使用は冗長になるため避ける)。
+
+```ts
+// NG: 短すぎる、または曖昧な名前
+const val = 10;
+const idx = users.findIndex(u => u.id === currentId);
+
+// OK: 明確で具体的な名前
+const maxLoginAttempts = 10;
+const targetUserIndex = users.findIndex(user => user.id === currentUserId);
+```
+
+## コメント
+
+- **「何をするか」でなく「なぜそうするか」を書く**。コードを読めば分かることはコメントしない。
+- 意図・背景・設計判断・パフォーマンス上の理由・セキュリティ上の理由など、コードに表れない情報のみ書く。
+
+```ts
+// NG: コードを読めば分かる
+// i を 1 増やす
+i++;
+
+// OK: なぜそうするのかを説明
+// セッション切れでリダイレクトされた場合、ログイン後に元のページに戻すために現在のパスを保存する。
+saveReturnToPath(currentPath);
+```
+
+## 文字列結合はテンプレートリテラル
+
+```ts
+// NG
+const message = "Hello, " + name + "! You have " + count + " messages.";
+
+// OK
+const message = `Hello, ${name}! You have ${count} messages.`;
+```
+
+## 条件分岐は三項演算子またはオブジェクトマッピング
+
+if-else 連鎖を避け、状態 → 値の対応はオブジェクトマップで表現する。
+
+```ts
+// NG
+function getStatus(status: string): string {
+  if (status === "pending") return "処理中";
+  if (status === "completed") return "完了";
+  if (status === "failed") return "失敗";
+  return "不明";
+}
+
+// OK
+const STATUS_MESSAGES = {
+  pending: "処理中",
+  completed: "完了",
+  failed: "失敗",
+} as const;
+
+function getStatus(status: keyof typeof STATUS_MESSAGES): string {
+  return STATUS_MESSAGES[status] ?? "不明";
+}
+```
+
+## import 順序
+
+1. 外部ライブラリ (`react` / `next` / `firebase` / `axios` など)
+2. UI フレームワーク (`@mui/material` / `@/components/ui` など)
+3. エイリアス (`@/hooks` / `@/lib` / `@/features`)
+4. 相対パス (`./Sibling` / `../Util`)
+
+```ts
+import { useState, useEffect } from "react";
+import { useAtom } from "jotai";
+import { z } from "zod";
+
+import { Button } from "@mui/material";
+
+import { useAuth } from "@/hooks/useAuth";
+import { API_BASE_URL } from "@/lib/constants";
+
+import { UserProfile } from "./UserProfile";
+import type { User } from "../types";
+```
+
+## 型安全性
+
+- **`any` 禁止**。型が分からない値は `unknown` を使い、絞り込んでから扱う。
+- **`default export` 禁止**。`export const Component` のような名前付き export を使う。
+- **`const` 原則**。再代入が必要な場合は別名変数を導入し、`let` は使わない。
+- マジックナンバー / マジックストリングは定数化する (`/constants` 配下に集約)。
+
+```ts
+// NG: any
+function processData(data: any): any { return data.map((item: any) => item.value); }
+
+// OK: 具体的な型
+type DataItem = { id: string; value: number };
+function processData(data: DataItem[]): number[] {
+  return data.map(item => item.value);
+}
+```
+
+```ts
+// NG: マジックナンバー
+if (user.age < 18) return "未成年";
+
+// OK: 定数化
+const LEGAL_AGE = 18;
+if (user.age < LEGAL_AGE) return "未成年";
+```
+
+## ループ禁止 (No Loops)
+
+`for` / `for...in` / `for...of` / `while` / `do...while` は禁止。配列 API で表現する。
+
+```ts
+// NG
+const results: number[] = [];
+for (let i = 0; i < items.length; i++) {
+  results.push(transform(items[i]));
+}
+
+// OK
+const results = items.map(transform);
+```
+
+| 目的 | 使う API |
+|---|---|
+| 変換 | `map` |
+| 抽出 | `filter` |
+| 集約 | `reduce` |
+| 平坦化 + 変換 | `flatMap` |
+| 副作用 | `forEach` |
+| 存在判定 | `some` / `every` / `find` |
+
+例外: ストリーミング処理など `for await...of` が必須な場面では使用可。コメントで理由を明示する。
+
+## Tailwind 利用ルール
+
+- **任意値構文 `[...]` を避ける**。サイズは `w-80` のような数値クラスを使い、色・フォントサイズ・角丸などのトークン化可能な値は `globals.css` のテーマトークンを通して参照する。
+- **不透明度修飾子 `-XXX/YY` (`text-gray-800/80` など) で色の濃淡を作らない**。「より薄い色が欲しい」場合は別のシェードクラスに切り替える (`text-gray-800` → `text-gray-700`)。本当に透過が必要な場合のみトークンを追加する。
+- 複雑なクラス結合は `twMerge` を使う。
+- shadcn/ui や MUI のプリミティブを優先的に使い、必要に応じて `variant` で拡張する。
+
+```tsx
+// NG: 任意値 + opacity による濃淡調整
+<div className="w-[327px] text-[13px] bg-[#1a1a1a] rounded-[10px] text-gray-800/80" />
+
+// OK: 数値クラス・トークン経由・シェード切替
+<div className="w-80 text-sm bg-background rounded-lg text-gray-700" />
+```
+
+## アニメーション
+
+- **Framer Motion** を採用する。`motion.div` などの薄いラッパーをレイアウト側で管理する。
+- 共通アニメーションは `front/components/animations` に集約する。

--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -1,0 +1,8 @@
+---
+title: Coding Style
+description: 命名・コメント・コードスタイル・Tailwind 利用ルール
+---
+
+# Coding Style
+
+(Phase 2 で内容を移植する)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -5,4 +5,150 @@ description: 単体テスト方針 (Vitest + Testing Library) と書き方
 
 # Testing
 
-(Phase 2 で内容を移植する)
+## テストを書くタイミング
+
+「後から誰かが変更したとき、このテストは回帰を捕捉できるか?」を基準に判断する。**全コンポーネントに機械的にテストを書かない**。
+
+- **純粋関数 (`utils.ts` などに置く関数)**: **必ずテストを書く**。同階層に `*.test.ts` を置き、すべての分岐をカバーする。
+- **コンポーネント**: 以下のいずれかに該当する場合に書く。該当しない静的なコンポーネントは省略してよい。
+  - 描画が props / 状態によって変化する (条件分岐がある)
+  - a11y 属性 (`aria-*` / `role` / `htmlFor` / `tabIndex` / キーハンドラ等) がある
+  - 上記に該当するコンポーネントを変更する場合 (回帰防止)
+- **Container**: データ取得をモックし、Presenter に渡す props を検証する。
+- **Presenter**: 上記「コンポーネント」基準に従う。a11y 属性のない静的描画ならテスト不要。
+
+判断基準: 「他の人が後でこのコンポーネントを変更したとき、意図しない変更をテストが捕捉できるか?」 — 価値のあるケースに `snapshot` / `getByRole` / `getByLabelText` 等で投資する。
+
+## ホワイトボックステスト
+
+入出力だけでなく、内部のロジックパスも検証する。
+
+## AAA パターン + 1 test = 1 expect
+
+すべてのテストは **Arrange / Act / Assert** に従う。1 ケースにつき `expect` は 1 つ。
+
+テスト名のフォーマット: `"should [expected behavior] when [condition]"` (日本語可)。
+
+### 純粋関数テスト — 全分岐をカバー
+
+```ts
+import { describe, it, expect } from "vitest";
+import { classifyTask } from "./utils";
+
+describe("classifyTask", () => {
+  it("should return 'do' when importance and urgency are both high", () => {
+    // Arrange
+    const importance = "high" as const;
+    const urgency = "high" as const;
+
+    // Act
+    const result = classifyTask(importance, urgency);
+
+    // Assert
+    expect(result).toBe("do");
+  });
+
+  it("should return 'schedule' when importance is high and urgency is low", () => {
+    // Arrange
+    const importance = "high" as const;
+    const urgency = "low" as const;
+
+    // Act
+    const result = classifyTask(importance, urgency);
+
+    // Assert
+    expect(result).toBe("schedule");
+  });
+});
+```
+
+### Presenter テスト — props バリエーションごとに検証
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TaskCard } from "./TaskCard";
+
+describe("TaskCard", () => {
+  it("should render title when given", () => {
+    // Arrange & Act
+    render(
+      <TaskCard
+        title="買い物"
+        importance="high"
+        urgency="low"
+        onToggleDone={() => {}}
+      />
+    );
+
+    // Assert
+    expect(screen.getByText("買い物")).toBeInTheDocument();
+  });
+});
+```
+
+### Container テスト — データ取得をモックし、Presenter に渡す props を検証
+
+データ取得フックをモックし、Presenter に正しい props が渡るかをアサートする。
+
+## テスト戦略
+
+- 純粋関数: すべての分岐パスをカバーする
+- Presenter: 各 props バリエーションを検証する
+- Container: データ取得をモックし、Presenter に渡す props を検証する
+- 境界値・エッジケースを明示的にテストする
+
+## 推奨ディレクトリ・ファイル命名
+
+- テストファイルは対象コンポーネント・関数の同階層に置き、`*.test.tsx` または `*.test.ts` を付ける
+- 共通ユーティリティ・モックは `front/test/` 配下にまとめる
+
+## ユーザー視点で検証
+
+- DOM 構造やクラス名でアサートしない (実装詳細をテストしない)
+- `getByRole` / `getByLabelText` / `getByText` などユーザー視点のクエリを優先する
+- インタラクションは **`user-event`** を使い、実際の操作を再現する
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+it("should call onToggleDone when complete button is clicked", async () => {
+  // Arrange
+  const onToggleDone = vi.fn();
+  render(<TaskCard title="買い物" importance="low" urgency="low" onToggleDone={onToggleDone} />);
+  const user = userEvent.setup();
+
+  // Act
+  await user.click(screen.getByRole("button", { name: "完了" }));
+
+  // Assert
+  expect(onToggleDone).toHaveBeenCalledTimes(1);
+});
+```
+
+## 共通セットアップ (`vitest.config.ts` / `test/setup.ts`)
+
+`@testing-library/jest-dom` と必要なら MSW サーバを `setupFiles` で初期化する。
+
+```ts
+// test/setup.ts (例)
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => cleanup());
+```
+
+API モックが必要な場合は `msw` を導入し、デフォルトハンドラを `front/test/mocks/handlers.ts` にまとめる。テスト内で `server.use()` を使い分岐ケース (例外 / 空配列 / 遅延) を個別に上書きする。
+
+## 実行
+
+```bash
+cd front
+yarn test:run             # 全テストを 1 回走らせる (CI 用)
+yarn test                 # watch モード (開発用)
+yarn test:coverage        # カバレッジ計測
+```
+
+カバレッジ閾値の目安は statements / branches **90%**。

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,8 @@
+---
+title: Testing
+description: 単体テスト方針 (Vitest + Testing Library) と書き方
+---
+
+# Testing
+
+(Phase 2 で内容を移植する)

--- a/.claude/rules/tools.md
+++ b/.claude/rules/tools.md
@@ -1,0 +1,8 @@
+---
+title: Tools
+description: Biome / Vitest / TypeScript / Next.js などツールの使い方
+---
+
+# Tools
+
+(Phase 2 で内容を移植する)

--- a/.claude/rules/tools.md
+++ b/.claude/rules/tools.md
@@ -5,4 +5,83 @@ description: Biome / Vitest / TypeScript / Next.js などツールの使い方
 
 # Tools
 
-(Phase 2 で内容を移植する)
+`front/` ディレクトリで実行する想定。
+
+## Biome (Lint + Format)
+
+設定: `front/biome.json`
+
+```bash
+cd front
+yarn lint:biome           # lint チェック (read-only)
+yarn lint:biome:fix       # lint 自動修正
+yarn format:biome         # フォーマット適用
+yarn check:biome          # lint + format 一括 (自動修正あり)
+```
+
+ESLint は `eslint` v8 + `eslint-config-next` が暫定的に併存しているが、Phase 2 で v9 + flat config に移行する。Biome を主、ESLint を Next.js 互換用 (`yarn lint`) として使い分ける。
+
+## TypeScript
+
+設定: `front/tsconfig.json`
+
+型チェック単体実行 (ファイルを生成しない):
+
+```bash
+cd front
+yarn run -T tsc --noEmit
+```
+
+`any` 禁止。型推論で困ったら `unknown` で受けて絞り込む。
+
+## Vitest (Unit Test)
+
+設定: `front/vitest.config.ts`
+
+```bash
+cd front
+yarn test:run             # 全テスト 1 回 (CI 用)
+yarn test                 # watch モード (開発用)
+yarn test:watch           # watch (上のエイリアス)
+yarn test:ui              # GUI (`@vitest/ui`)
+yarn test:coverage        # V8 カバレッジ計測
+```
+
+書き方は `.claude/rules/testing.md` を参照。
+
+## Next.js (App Router)
+
+```bash
+cd front
+yarn dev                  # 開発サーバ (http://localhost:3000)
+yarn build                # プロダクションビルド
+yarn start                # ビルド済みアプリの起動
+yarn lint                 # next lint (ESLint 経由)
+```
+
+App Router を使う。Pages Router と混在しない (新規ページは `app/` 配下に作る)。
+
+## Firebase
+
+`front/app/firebase.js` で初期化。Auth / Firestore / Storage を利用。Firestore のドキュメント ID は `addDoc(collection(...))` 等で自動採番を推奨 (`setDoc(doc(db, "tasks", title))` のような ID 衝突を避ける)。
+
+## Docker (任意)
+
+リポジトリルートで `docker compose up --build` するとフロント (3000) とバックエンド (5001) が起動する。
+
+## Claude Code 関連 (本リポジトリ独自)
+
+- `CLAUDE.md` (リポジトリルート): セッション起動時に自動ロードされる。`@.claude/rules/*.md` で本ディレクトリのルールを include する。
+- `.claude/settings.json` / `.claude/settings.local.json`: permissions / hooks / MCP enable / plugins。後者は git 管理外。
+- `.claude/skills/<name>/SKILL.md`: ユーザー or AI 自律呼び出し可能なスキル。
+- `.mcp.json`: MCP サーバー定義 (将来 `context7` を追加予定、サブ #67)。
+
+## 将来導入予定 (本仕様書 Phase 1 / サブ ISSUE)
+
+- **lefthook** (git hook): pre-commit / pre-push で lint + typecheck (人間操作の境界)
+- **knip** (サブ #68): 未使用 export / file / dependency の検出
+- **similarity-ts** (サブ #69): 重複した型・関数の検出
+- **Claude hooks** (サブ #63 / #64 / #70): PostToolUse での lint+typecheck、Stop での品質ゲート、knip / similarity-ts 統合
+- **permissions** (サブ #62): 破壊的コマンドのブロック
+- **/commit skill** (サブ #66): 1 コミット = 1 意図のコミット分割支援
+- **context7 MCP** (サブ #67): ライブラリ最新仕様の取得

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# LastMatorix — Claude Code Project Rules
+
+緊急度 × 重要度 (アイゼンハワー・マトリクス) に基づくタスク管理アプリ。Next.js 15 (App Router) + React 19 + Firebase + MUI v5 + Tailwind v3 + Vitest 構成。
+
+このファイルは Claude Code セッション起動時に自動ロードされる。プロジェクト規約は以下のトピック別ファイルに分割しており、`@` 記法で本セッションプロンプトに注入される。**.cursor/rules ではなく本 CLAUDE.md と `.claude/rules/*.md` を正典とする** (差分理由は `README.md` を参照)。
+
+@.claude/rules/style.md
+@.claude/rules/architecture.md
+@.claude/rules/testing.md
+@.claude/rules/dependencies.md
+@.claude/rules/tools.md
+
+## 主要ドキュメント
+
+- `issue-commit-guidelines.md` — ISSUE 設計 / コミット粒度の正典
+- `仕様書テンプレート.md` — 仕様書のひな形
+- `仕様書-Claude-Code活用基盤整備.md` — Claude Code 活用基盤整備の仕様 (本 CLAUDE.md / hooks / permissions / skills のロードマップ)
+- `README.md` — リポジトリ全体の概要、`.cursor/rules` と `.claude/rules` の対応関係
+
+## ディレクトリ概要
+
+```
+front/                Next.js (App Router) アプリ
+backend/              Flask スクレイピングアプリ
+.claude/              Claude Code 設定 (rules / settings / skills)
+.cursor/              Cursor 設定 (rules)
+docker-compose.yml
+```
+
+## 作業の前に
+
+- ISSUE 起点で着手する場合は `/start-issue <番号>` skill を使う (詳細は `.claude/skills/start-issue/SKILL.md`)。
+- コミット粒度・タイトル命名・ブランチ規則は `issue-commit-guidelines.md` に従う。
+- 規約に違反する変更を提案された場合、本ファイル + `@.claude/rules/*.md` を優先する。

--- a/README.md
+++ b/README.md
@@ -134,3 +134,25 @@ python app.py
 - UI: Tailwind CSS, MUI
 - 画像: `next.config.js` で `firebasestorage.googleapis.com` を許可
 - スタイル: `front/app/globals.css`
+
+## コーディング規約
+
+プロジェクトのコーディング規約は **`CLAUDE.md` と `.claude/rules/*.md` を正典**とする。Claude Code セッション起動時に自動ロードされる。
+
+### `.claude/rules` (5 本) と `.cursor/rules` (7 本) の対応
+
+| `.claude/rules/*.md` | 対応する `.cursor/rules/*.mdc` |
+|---|---|
+| `style.md` | `02-naming-and-comments.mdc` + `03-code-style.mdc` |
+| `architecture.md` | `01-functional-programming.mdc` + `04-state-mutable.mdc` + `05-component-design.mdc` + `06-project-structure.mdc` |
+| `testing.md` | `07-testing-guideline.mdc` |
+| `dependencies.md` | (新規) — Phase 2 ロードマップ・バージョン固定方針 |
+| `tools.md` | (新規) — Biome / Vitest / TypeScript / Next.js / 将来導入予定の Claude hooks ほか |
+
+`.cursor/rules/taskdoc.mdc` はタスクドキュメントテンプレートでありルール本体ではないため移植対象外。`仕様書テンプレート.md` で代替する。
+
+### `.cursor/rules` との差分理由
+
+- `.cursor/rules` は Cursor 用に書かれており、Tailwind v3 / MUI v5 前提のまま据え置かれている。
+- `.claude/rules` は LastMatorix の現状スタック (yarn / Biome / Vitest / Next.js 15 App Router / React 19) に合わせて書き換え、加えて [imaimai17468/imaimai-front-templete](https://github.com/imaimai17468/imaimai-front-templete) のルール構成 (Colocation / Container-Presenter / No Loops / Tailwind 任意値回避 / AAA + 1 expect / Exact Version Pinning) を取り込んでいる。
+- 差分があった場合は `CLAUDE.md` 側を優先する (本リポジトリ ISSUE #61 の方針)。


### PR DESCRIPTION
## 概要

refront ブランチ上で PR #79 としてマージ済みだった「Claude Code 規約自動適用 (#61)」を main に cherry-pick で反映する。
main ブランチで Claude Code セッションを起動した際に、規約ファイルが自動ロードされるようになる。

## 関連Issue

close #93

## 変更内容

- [x] `.claude/rules/` ディレクトリに 5 本の骨組みファイルを追加 (`chore`)
- [x] `.cursor/rules/*.mdc` の内容を `.claude/rules/*.md` に正規化移植 (`refactor`)
- [x] `CLAUDE.md` をリポジトリルートに追加し `@.claude/rules/*.md` を @include 設定 (`feat`)
- [x] `README.md` に `.cursor/rules` と `.claude/rules` の対応関係を追記 (`docs`)

## スクリーンショット（UI変更の場合）

なし (設定ファイル・ドキュメント変更のみ)

## テスト結果

`next lint`: ✔ No ESLint warnings or errors — 既存コードへの影響なし

## チェックリスト

- [x] コーディング規約に準拠している
- [x] 必要なテストを追加した
- [x] すべてのテストが成功している
- [x] ドキュメントを更新した（必要な場合）
- [x] コンフリクトを解消した

## 備考

- 親 ISSUE: #80 (refront → main 反映ハブ、CLOSED)
- cherry-pick 元: refront ブランチ (PR #79 が既マージ済み)
- refront 経由マージは行わず、4 コミットを個別に cherry-pick (refront 廃止戦略に整合)
- cherry-pick ハッシュ: `5df6ee81` → `495e68a6` → `57ea09dd` → `10e65043`
- 旧 ISSUE #61 は本 PR マージ後に Close 候補