### PR TITLE
feat: 編集後 lint/typecheck を PostToolUse hook で自動実行する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "F=$(jq -r '.tool_input.file_path // \"\"'); case \"$F\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;; *) exit 0 ;; esac; cd \"$CLAUDE_PROJECT_DIR/front\" && OUT=$(yarn lint:biome 2>&1 && yarn run -T tsc --noEmit 2>&1); RC=$?; if [ $RC -ne 0 ]; then printf '%s' \"$OUT\" | jq -Rs --arg file \"$F\" '{systemMessage:(\"⛔ PostToolUse block: lint/typecheck 失敗 — \" + $file), decision:\"block\", reason:(\"PostToolUse: 編集後の lint / typecheck が失敗しました。次のツール呼び出し前に直してください。\\n\\n\" + .)}'; fi; exit 0",
+            "command": "F=$(jq -r '.tool_input.file_path // \"\"'); case \"$F\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;; *) exit 0 ;; esac; cd \"$CLAUDE_PROJECT_DIR/front\" || exit 0; LINT_OUT=$(yarn run -T biome lint \"$F\" 2>&1); LRC=$?; TYPE_OUT=$(yarn run -T tsc --noEmit 2>&1); TRC=$?; echo \"$TYPE_OUT\" | grep -q \"TS18003\" && TRC=0; if [ $LRC -ne 0 ] || [ $TRC -ne 0 ]; then printf '%s\\n%s' \"$LINT_OUT\" \"$TYPE_OUT\" | jq -Rs --arg file \"$F\" '{systemMessage:(\"⛔ PostToolUse block: lint/typecheck 失敗 — \" + $file), decision:\"block\", reason:(\"PostToolUse: 編集後の lint / typecheck が失敗しました。次のツール呼び出し前に直してください。\\n\\n\" + .)}'; fi; exit 0",
             "timeout": 60,
             "statusMessage": "Per-edit check: lint + typecheck..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -85,5 +85,20 @@
       "Bash(yarn:*)"
     ]
   },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "F=$(jq -r '.tool_input.file_path // \"\"'); case \"$F\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;; *) exit 0 ;; esac; cd \"$CLAUDE_PROJECT_DIR/front\" && OUT=$(yarn lint:biome 2>&1 && yarn run -T tsc --noEmit 2>&1); RC=$?; if [ $RC -ne 0 ]; then printf '%s' \"$OUT\" | jq -Rs --arg file \"$F\" '{systemMessage:(\"⛔ PostToolUse block: lint/typecheck 失敗 — \" + $file), decision:\"block\", reason:(\"PostToolUse: 編集後の lint / typecheck が失敗しました。次のツール呼び出し前に直してください。\\n\\n\" + .)}'; fi; exit 0",
+            "timeout": 60,
+            "statusMessage": "Per-edit check: lint + typecheck..."
+          }
+        ]
+      }
+    ]
+  },
   "enabledMcpjsonServers": ["context7"]
 }


### PR DESCRIPTION
## 概要

`.claude/settings.json` の `hooks.PostToolUse` を新規追加し、Claude Code が `Edit` / `Write` / `MultiEdit` でファイルを書き換えた直後に `front/` 配下で biome lint + `tsc --noEmit` を自動実行する。仕様書 `仕様書-Claude-Code活用基盤整備.md` の Phase 1 / A-#3「編集後の即時品質チェック機能」に対応する。

## 関連Issue

close #63

## 変更内容

- [x] `.claude/settings.json` の `hooks.PostToolUse` に `Edit|Write|MultiEdit` matcher を追加 (timeout 60 秒, statusMessage `Per-edit check: lint + typecheck...`)
- [x] 対象拡張子を `.ts` / `.tsx` / `.js` / `.jsx` / `.mjs` / `.cjs` に限定し、それ以外 (`.md` / `.json` 等) は即 `exit 0` で no-op
- [x] 失敗時は `{systemMessage, decision:"block", reason}` 形式の JSON を stdout に流し、Claude Code に修正ループを促す
- [x] 編集ファイル単独 lint (`yarn run -T biome lint "$F"`) で関心の分離を確保 (590c91d6)
- [x] yarn 4 の tsc ラッパーが TS18003 を exit 1 で返す問題を `TS18003` 文字列マッチでガード (590c91d6)

## スクリーンショット（UI変更の場合）

UI 変更なし。

## テスト結果

本セッションで実発火検証を行い、以下を確認した:

- **正常パス**: 完全に valid な `.ts` ファイルを Write した直後に hook が発火し、`Per-edit check: lint + typecheck...` (statusMessage) が表示され、block されずに次のターンへ進む
- **失敗パス**: 既存違反を持つ `front/ui/TaskList.jsx` を `$F` に渡すと `LRC=1` で `WOULD BLOCK`、生成された JSON は `systemMessage:"⛔ PostToolUse block: lint/typecheck 失敗 — <file>"` / `decision:"block"` / `reason:"PostToolUse: 編集後の lint / typecheck が失敗しました。..."` の形で正しく整形される
- **アイソレーション**: TaskList.jsx 編集時に他ファイル (Profile/page.jsx, AccountCreating/page.jsx 等) の違反は混入しない (編集ファイル単独 lint への絞り込みが機能している)
- **tsc 空入力ガード**: `.ts/.tsx` ファイル 0 件の現状で tsc が `error TS18003` を返しても `TRC=0` に補正され、block 発動しない
- **拡張子フィルタ**: `.ts/.tsx/.js/.jsx/.mjs/.cjs/.md/.json/.txt` の 9 ケースを bash で確認し、対象外拡張子は即 `exit 0`

### マージ前にローカルで再確認してほしいこと

PostToolUse hook は `.claude/settings.json` の更新が **新規セッション起動時に読み込まれる** ため、本セッションのフック実体は初版コミットのもの。コマンドそのものは手動再現で正しさを確認したが、新セッションでも以下を一度通してほしい:

1. Claude Code を一旦終了して再起動 (このブランチをチェックアウトした状態で)
2. 任意の `.ts` ファイルを軽微に Edit させ、status バーに `Per-edit check: lint + typecheck...` が出ることを確認
3. わざと lint 違反を混入させ、`⛔ PostToolUse block: lint/typecheck 失敗` が次のターンに reason として fed back されることを確認 (Edit/Write 自体は完了し、Claude が次のアクションでその reason を受け取って修正対応する)
4. `.md` 編集では何も走らないことを確認 (no-op)

## チェックリスト

- [x] コーディング規約に準拠している
- [ ] 必要なテストを追加した (hook 設定のため自動テスト対象外。本 PR の「テスト結果」セクションに手動検証ログを記載)
- [x] すべてのテストが成功している (手動検証で正常パス / 失敗パス / アイソレーション / tsc 空入力ガード / 拡張子フィルタすべて確認)
- [ ] ドキュメントを更新した（必要な場合） (本 PR は設定変更のみのため対象外)
- [x] コンフリクトを解消した

## 備考

### 検証で発覚した問題と追加修正 (590c91d6)

初版実装 (9bdcb217) には以下 2 点の実用上のバグがあったため、追加コミットで修正した:

1. `yarn lint:biome` (= `biome lint .`) が front 全体を lint するため、編集ファイルと無関係な既存違反 (現状 13 errors) でも常に block 発動していた → `yarn run -T biome lint "$F"` で編集ファイル単独に絞ることで解消
2. yarn 4 の tsc ラッパーが TS18003 (No inputs were found) を exit 1 として返すため、TypeScript ファイル 0 件の現状で常に block 発動していた → stderr の `TS18003` 文字列マッチでガード (TS 化が進めば自動で機能する設計は維持)

### 設計判断

- ISSUE 本文の実装イメージのワンライナーをほぼそのまま採用 (lint と typecheck の連結 + jq による block JSON 整形)
- Yarn 4.1.0 (Berry) 環境で `-T` (`--top-level`) フラグが有効であることを `yarn --version` で確認済み
- `cd "$CLAUDE_PROJECT_DIR/front"` で front 配下に移動。フロント以外は当面対象外 (ISSUE「含まないもの」に従う)

### 関連作業 (本 PR の対象外)

- 既存 13 errors / 13 warnings の整理 (auto-fix + `a11y/useButtonType` の手動修正) は hook 機構の導入とは別関心事のため、別 ISSUE として起票し縦切りで対応する
