### PR TITLE
docs: ROADMAP から refront ライフサイクル節を除去する

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,6 @@
 | --- | --- | --- | --- |
 | 親A | Claude Code 活用基盤整備 | #60 | OPEN |
 | 親B | 依存関係最新化 | #71 | OPEN |
-| 親C | refront ブランチを main に反映 | #80 | OPEN (#81 のみ Close) |
 | Phase3 | 状態管理導入 (Jotai) | — | 未起票 |
 | Phase4 | 機能別フォルダ構成移行 | — | 未起票 |
 
@@ -20,50 +19,20 @@
 
 ```mermaid
 flowchart TB
-  subgraph Found[基盤フェーズ 並走可]
-    A[親A: Claude Code 基盤 #60]
-    C[親C: refront 反映 #80]
-  end
+  A[親A: Claude Code 基盤 #60]
   B[親B: 依存関係更新 #71]
   P3[Phase3: Jotai 未起票]
   P4[Phase4: 機能別フォルダ 未起票]
 
   A --> B
-  C --> B
   B --> P3
   P3 --> P4
 ```
 
 1. **親A** を独立サブから 3 並列で着手 — リファクタの安全網を先に張る
-2. **親C** を **親A と並走** — refront 上の既マージ作業を main へ取り込む
-3. **親B** — 親A の品質ゲートと親C の Biome/Vitest 土台が揃ってから
-4. **Phase3** (Jotai) — 起票して着手
-5. **Phase4** (機能別フォルダ) — Phase3 完了後
-
-## refront ライフサイクル
-
-`refront` は 2025-08-08 に main から分岐した長命統合ブランチ。当初は土台整備作業 (依存更新 / Docker 削除 / Biome / Vitest など) を main から隔離する目的で作成され、2026-05 時点で 27 コミット (5 トピック) が main 未反映で累積している。
-
-3 観点 (Git 一般原則 / refront 事実調査 / 戦略提案) で考察した結果、**1 人開発の規模に対して長命 staging ブランチの維持コストが過剰** (スコアカード 14/25) との結論。以下の方針で段階的に廃止する。
-
-### 採用方針: 案 A「使命完遂後アーカイブ」
-
-| ステップ | 内容 | 担当 ISSUE | 状態 |
-| --- | --- | --- | --- |
-| 1 | 親C #80 全サブを完遂 (#81 ✅ / #82 / #83 / #84 / #85) | 各サブ | 進行中 |
-| 2 | refront 上にあって親C スコープ外の作業を別途 main 反映 (主に PR #79 = #61 規約自動適用) | C-6 = #93 | 起票済 |
-| 3 | refront → main 差分が 0 になることを確認 | C-7 内手順 | 未着手 |
-| 4 | `git tag archive/refront-2026-05 origin/refront && git push --tags` で歴史を固定 | C-7 = #94 | 起票済 |
-| 5 | `git push origin --delete refront` でリモート削除、#80 を Close | C-7 = #94 | 未着手 |
-| 6 | 以降は **全 ISSUE を main ベース** で運用 (例外なし) | — | ステップ 5 後 |
-
-**撤退条件**: ステップ 3 で予期せぬ差分 (cherry-pick 漏れ等) が発見され、回復に 2 PR 以上を要すると判明した場合は戦略を再検討する。アーカイブ後に問題が判明した場合は `git checkout -b refront-restored archive/refront-2026-05` で復旧可能。
-
-### 期間中の運用ルール
-
-- **新規 ISSUE のベース**: 原則 `main`。ただし refront にある未反映作業に依存する場合に限り、当該サブ ISSUE で個別判断 (PR 説明文に依存先を明記)
-- **refront への新規コミット禁止**: 累積を増やさない (PR #79 のような「親C スコープ外がまた refront に乗る」事故の再発防止)
-- **採用根拠の出典**: Pro Git Book Ch.3 / GitHub Docs "GitHub flow" / Atlassian "Comparing Workflows"
+2. **親B** — 親A の品質ゲートと Biome/Vitest 土台が揃ってから
+3. **Phase3** (Jotai) — 起票して着手
+4. **Phase4** (機能別フォルダ) — Phase3 完了後
 
 ## 親A: Claude Code 活用基盤整備 (#60)
 
@@ -71,7 +40,7 @@ flowchart TB
 
 | ID | 内容 | ISSUE | 状態 | 触るファイル | 並列性 / 前提 |
 | --- | --- | --- | --- | --- | --- |
-| A-#1 | 規約自動適用 | #61 | OPEN ⚠️ | `CLAUDE.md`, `.claude/rules/*.md` | refront 上に PR #79 で **既にマージ済み**。main 反映は親C C-6 (#93) で対応 |
+| A-#1 | 規約自動適用 | #61 | OPEN ⚠️ | `CLAUDE.md`, `.claude/rules/*.md` | main 反映は #102 (廃止プロジェクト #99 のサブ) で対応 |
 | A-#2 | 破壊操作ブロック | #62 | OPEN | `.claude/settings.json` (新規) | 独立。settings.json 共有: #63/#64/#67 より先に入れる |
 | A-#3 | PostToolUse: 編集ごと lint/typecheck | #63 | OPEN | `.claude/settings.json` (hooks 追記) | 要 #62 + #83 (Biome) + typecheck script |
 | A-#4 | Stop: 基本品質ゲート | #64 | OPEN | `.claude/hooks/`, `settings.json` (hooks) | 要 #63 |
@@ -88,7 +57,7 @@ flowchart TB
 | --- | --- | --- | --- |
 | 第1 | **#66 + #82(β) + #62** | なし | A-#6 と β と A-#2 を 3 並列 |
 | 第2 | #67 | #62 と settings.json 共有 | #62 完了後に追記 |
-| 第3 | #83 → #84 (親C 経由) | — | typecheck/lint/test の土台を整備 |
+| 第3 | #83 → #84 | — | typecheck/lint/test の土台を整備 |
 | 第4 | #63 → #64 | settings.json hooks 追記 | 第3完了後 |
 | 第5 | #68 / #69 / #70 | — | 親B 完了後がベター (バージョンアップで未使用が変動) |
 
@@ -105,20 +74,6 @@ flowchart TB
 | B-#7 | ESLint v8 → v9 (旧 #56 置換) | #78 | OPEN | 3 |
 
 仕様書 §「Phase 2」記載の通り、MUI は v6 を中継せず v5 → v7 に一気に上げる。
-
-## 親C: refront ブランチを main に反映 (#80)
-
-refront ブランチには main 未反映のコミットが 4 トピックある。順次サブ ISSUE で main へ取り込む。
-
-| サブ | 内容 | ISSUE | 状態 | refront 上のコミット |
-| --- | --- | --- | --- | --- |
-| C-1 | Node.js / ライブラリ更新と Next.js 設定簡略化を main に反映 | #81 | **CLOSED ✅** | PR #86 で main 反映済 |
-| C-2 | Docker 関連削除と gitignore 整理を main に反映 | #82 | OPEN | `bc137c71` / `78923f8f` / `fa48bce4` (元 PR #50) |
-| C-3 | Biome を導入する | #83 | OPEN | `406571c7` / `fd14692d` / `f981ad41` / `40b15141` (元 PR #58) |
-| C-4 | Vitest と Firestore テスト整備を導入する | #84 | OPEN | `b5793d4a` / `ee82e6fa` / `997466fc` / `500f879b` / `6b6c18ed` / `ed98c965` (元 PR #59) |
-| C-5 | ISSUE / ブランチ運用ルールを issue-commit-guidelines.md に追記する | #85 | OPEN | (新規作業) |
-| C-6 | #61 (Claude Code 規約自動適用) を main に反映する | #93 | OPEN | refront 上 PR #79 の 4 commit (`5df6ee81` / `495e68a6` / `57ea09dd` / `10e65043`) を cherry-pick で取り込む |
-| C-7 | refront ブランチをアーカイブタグ化して削除する | #94 | OPEN | 親C 全サブ + C-6 完了後に着手。手順は §「refront ライフサイクル」参照 |
 
 ## 未起票フェーズ
 
@@ -166,8 +121,8 @@ refront ブランチには main 未反映のコミットが 4 トピックある
 | ローカル文書 | 対応する施策 |
 | --- | --- |
 | `仕様書-Claude-Code活用基盤整備.md` | 親A 全体 (#60 + #61〜#70) |
-| `front/docs/Phase1_Docker設定統一.md` | サブ #82 の補足 (refront 反映の背景) |
-| `front/docs/Phase2_開発環境刷新.md`, `Phase2/01〜06` | 親C #83/#84 + 親B #77/#78 の補足 |
+| `front/docs/Phase1_Docker設定統一.md` | サブ #82 の補足 |
+| `front/docs/Phase2_開発環境刷新.md`, `Phase2/01〜06` | #83/#84 + 親B #77/#78 の補足 |
 | `front/docs/Phase3_状態管理導入.md` | Phase3 起票の元ネタ |
 | `front/docs/Phase4_機能別フォルダ構成移行.md` | Phase4 起票の元ネタ |
 | `front/docs/現状把握_LastMatorix.md` | 全フェーズの背景資料 |
@@ -176,3 +131,4 @@ refront ブランチには main 未反映のコミットが 4 トピックある
 
 - **2026-05-04** 初版作成。親A/B/C と Phase3/4 を整理。#61 が refront 上で実装済み (PR #79) で main 未反映であることを明記。
 - **2026-05-04 (第2版)** §「refront ライフサイクル」節を新設し、**案 A「使命完遂後アーカイブ」** を採用方針として確定 (3 観点考察に基づく)。親C 表に C-6 (#93 = #61 main 反映) と C-7 (#94 = refront アーカイブ化) を追加。「親C スコープ外」節を削除し C-6 として親C に統合。
+- **2026-05-04 (第3版)** refront ブランチ廃止 (#99) に伴い、§「refront ライフサイクル」節と §「親C: refront ブランチを main に反映」節、関連参照を除去。親A A-#1 の備考は #102 経由に更新。


### PR DESCRIPTION
## What changed
- `ROADMAP.md` から §「refront ライフサイクル」節 (案 A 採用方針 / ステップ表 / 撤退条件 / 期間中の運用ルール) を削除
- §「親C: refront ブランチを main に反映 (#80)」節 (C-1〜C-7 テーブル) を削除
- 親 ISSUE テーブル / mermaid / 推奨実施順 / 親A A-#1 備考 / 着手順序 / Phase 補足 から refront 参照と dangling な親C 参照を整理
- 更新履歴に第3版として経緯を historical 注記で追加

## Why
- 親 ISSUE #99 (refront ブランチ廃止プロジェクト) の一環。サブ A (#100) で `issue-commit-guidelines.md` は main 一本運用に書き換え済み。本 ISSUE で ROADMAP も整合させる。

## Verification
- `grep -n refront ROADMAP.md` のヒットは更新履歴 3 行のみ (historical 注記、完了条件 2 を満たす)
- 節番号体系の齟齬なし (親A / 親B / Phase3 / Phase4 / 旧 ISSUE / 進行ルール / 更新履歴 の体系維持)
- 差分: +9 / -53 = net -44 行 (ISSUE 想定 30〜50 行内)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)