### PR TITLE
#111 biome FIXABLE warnings 13 件を auto-fix で解消

### DIFF
--- a/front/app/(auth)/AccountCreating/page.jsx
+++ b/front/app/(auth)/AccountCreating/page.jsx
@@ -24,7 +24,7 @@ export default function Page() {
       createUserWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
           // サインイン
-          const user = userCredential.user;
+          const _user = userCredential.user;
           router.push('/CreateProfile');
         })
         .catch((error) => {

--- a/front/app/(auth)/Auth/page.jsx
+++ b/front/app/(auth)/Auth/page.jsx
@@ -1,5 +1,4 @@
 'use client';
-import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';

--- a/front/app/(auth)/Login/page.jsx
+++ b/front/app/(auth)/Login/page.jsx
@@ -27,7 +27,7 @@ export default function Page() {
   const handleLogin = (e) => {
     e.preventDefault();
     signInWithEmailAndPassword(auth, email, password)
-      .then((userCredential) => {
+      .then((_userCredential) => {
         // ログイン成功時の処理
         alert('ログインしました');
         router.push('/Home');

--- a/front/app/Profile/page.jsx
+++ b/front/app/Profile/page.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { auth, db } from '../firebase';
 import { doc, getDoc } from 'firebase/firestore';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -52,7 +52,7 @@ export default function ProfilePage() {
         <div className="flex flex-col items-center">
           <div className=" w-96 h-64 mb-3 items-center flex justify-center">
             <Image
-              src={user && user.iconUrl ? user.iconUrl : '/default-icon.svg'}
+              src={user?.iconUrl ? user.iconUrl : '/default-icon.svg'}
               width={250}
               height={250}
               alt={user ? user.name : 'プロフィール画像'}

--- a/front/ui/AddTask.jsx
+++ b/front/ui/AddTask.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import CreateOutlinedIcon from '@mui/icons-material/CreateOutlined';
 import { addDoc, collection } from 'firebase/firestore';
 import { auth, db } from '../app/firebase';

--- a/front/ui/Days.jsx
+++ b/front/ui/Days.jsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function Days() {
   const [date, setDate] = useState(null);

--- a/front/ui/Menu.jsx
+++ b/front/ui/Menu.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import Days from './Days';
 import ProfileCard from './ProfileCard';
 import TaskList from './TaskList';

--- a/front/ui/NicoNico.jsx
+++ b/front/ui/NicoNico.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import './NicoNico.css';
 
 export default function NicoNico({ comment }) {

--- a/front/ui/TaskCard.jsx
+++ b/front/ui/TaskCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 
 export default function TaskCard({ task, onCheckboxChange, onCardClick }) {
   // 現在の日付をJSTで取得

--- a/front/ui/TaskList.jsx
+++ b/front/ui/TaskList.jsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import CloseIcon from '@mui/icons-material/Close';
 import { auth, db } from '../app/firebase';
 import {
   query,
   collection,
-  onSnapshot,
   doc,
   updateDoc,
   deleteDoc,
@@ -13,7 +12,6 @@ import {
 } from 'firebase/firestore';
 import DatePicker from 'react-datepicker';
 import TaskCard from './TaskCard'; // TaskCardコンポーネントの実装は未定義
-import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import 'react-datepicker/dist/react-datepicker.css';
 
 export default function TaskList() {


### PR DESCRIPTION
# #111 biome FIXABLE warnings 13 件を auto-fix で解消

## 概要

`front/` 配下の biome FIXABLE warnings 13 件を、対象 4 ルールに絞った `--write --unsafe` で機械的に解消。差分は計 23 行 (+10 / -13)、振る舞い変更なし。

| ルール | 件数 | auto-fix の挙動 |
|---|---|---|
| `correctness/noUnusedImports` | 11 | 未使用 import 削除 |
| `correctness/noUnusedVariables` | 1 | `_` プレフィックスで抑制 |
| `correctness/noUnusedFunctionParameters` | 1 | `_` プレフィックスで抑制 |
| `complexity/useOptionalChain` | 1 | `user && user.iconUrl` → `user?.iconUrl` |

## 関連Issue

close #111
Refs #110

## 変更内容

- [x] `yarn run biome lint --write --unsafe --only=correctness/noUnusedImports --only=correctness/noUnusedVariables --only=correctness/noUnusedFunctionParameters --only=complexity/useOptionalChain app ui` を実行
- [x] 触ったファイル 10 件: `app/(auth)/{Auth,AccountCreating,Login}/page.jsx`, `app/Profile/page.jsx`, `ui/{AddTask,Days,Menu,NicoNico,TaskCard,TaskList}.jsx`
- [x] `--only=` で 4 ルールに明示限定し、サブ #112 / #113 のスコープ (a11y errors 13 件) に侵入しないようガード

### Out of scope

- a11y errors 13 件 (`useButtonType` 11 / `noStaticElementInteractions` 1 / `useKeyWithClickEvents` 1) は据え置き — サブ #112 / #113 で扱う

## スクリーンショット（UI変更の場合）

該当なし (UI 変更なし、未使用 import 削除 / `_` プレフィックス / `?.` 変換のみ)。

## テスト結果

- `yarn run biome lint app ui` で warnings 13 → **0** (errors 13 件 a11y は据え置き、想定通り)
- `yarn build` で全 12 ページ静的生成 / 型チェック通過
- `git diff` の内容が「未使用 import 削除 + `_` プレフィックス + `?.` 変換」のみ (目視確認済)
- `yarn dev` での画面描画確認は未実施 (要レビュー時手動確認)

## チェックリスト

- [x] コーディング規約に準拠している
- [ ] 必要なテストを追加した (該当なし: auto-fix のみで振る舞い変更なし)
- [x] すべてのテストが成功している (build + biome lint クリア)
- [ ] ドキュメントを更新した（必要な場合）(該当なし)
- [x] コンフリクトを解消した (origin/main と完全同位置から分岐、コンフリクトなし)

## 備考

- `useOptionalChain` は通常の `yarn lint:biome` には警告として出ていなかった (デフォルト設定で dormant) が、`--only=` 指定で活性化して 1 件 fix。ISSUE 本文の想定と一致。
- `Menu.jsx` / `TaskCard.jsx` で `import React from 'react';` が空行 1 行として残る (biome auto-fix の癖、機能影響なし)。
