### PR TITLE
#112 <button> 11 箇所に type="button" を付与する

### DIFF
--- a/front/app/(auth)/Auth/GoogleAuth.jsx
+++ b/front/app/(auth)/Auth/GoogleAuth.jsx
@@ -31,7 +31,7 @@ export function GoogleLogin() {
   };
   return (
     <div>
-      <button onClick={handleGoogle} className="focus:outline-none">
+      <button type="button" onClick={handleGoogle} className="focus:outline-none">
         <div className="flex flex-col justify-center items-center space-y-2 transition-transform duration-150 ease-in-out transform hover:scale-105">
           <div>googleアカウントでログイン</div>
           <Image src="/google.svg" width={50} height={50} alt="Google" />

--- a/front/app/(auth)/Auth/page.jsx
+++ b/front/app/(auth)/Auth/page.jsx
@@ -19,6 +19,7 @@ export default function AuthPage() {
         <h1 className="text-[54px] font-bold text-gray-800">Matodo</h1>
 
         <button
+          type="button"
           className="text-white bg-[#00ADB5] hover:bg-blue-700 font-bold py-3 px-4 rounded w-full transition-transform duration-150 ease-in-out transform hover:scale-105 shadow-xl"
           onClick={handleCreate}
         >
@@ -26,6 +27,7 @@ export default function AuthPage() {
         </button>
 
         <button
+          type="button"
           className="text-gray-800 bg-white border border-gray-300 hover:bg-gray-100 font-bold py-3 px-4 rounded w-full transition-transform duration-150 ease-in-out transform hover:scale-105 shadow-xl"
           onClick={handleLogin}
         >

--- a/front/app/Profile/page.jsx
+++ b/front/app/Profile/page.jsx
@@ -62,18 +62,21 @@ export default function ProfilePage() {
           <p className="text-lg font-semibold">{user ? user.name : '読み込み中...'}</p>
           <p className="text-sm">{user ? user.position : '役職'}</p>
           <button
+            type="button"
             onClick={handleHome}
             className="mt-4 w-full bg-[#BDAE93] text-white font-bold py-2 px-4 rounded-lg space-y-1 transition-transform duration-150 ease-in-out transform hover:scale-105 shadow-xl"
           >
             マトリックスに戻る
           </button>
           <button
+            type="button"
             onClick={handleLogin}
             className="mt-4 w-full bg-[#00ADB5] text-white font-bold py-2 px-4 rounded-lg space-y-1 transition-transform duration-150 ease-in-out transform hover:scale-105 shadow-xl"
           >
             アカウントを変更
           </button>
           <button
+            type="button"
             onClick={handleSignOut}
             className="mt-4 w-full bg-[#FF6B6B] text-white font-bold py-2 px-4 rounded-lg transition-transform duration-150 ease-in-out transform hover:scale-105 shadow-xl"
           >

--- a/front/ui/MatrixArea.jsx
+++ b/front/ui/MatrixArea.jsx
@@ -23,7 +23,11 @@ function TaskCategory({ title, tasks, bgColorFrom, bgColorTo }) {
         </div>
       ))}
       {tasks.length > 4 && (
-        <button onClick={() => setShowAll(!showAll)} className="text-white mt-2 hover:underline">
+        <button
+          type="button"
+          onClick={() => setShowAll(!showAll)}
+          className="text-white mt-2 hover:underline"
+        >
           {showAll ? (
             <>
               <ArrowDropUpIcon /> 折りたたむ
@@ -105,6 +109,7 @@ export function MatrixArea() {
       className={`${gradientClasses} grid grid-cols-2 grid-rows-2 gap-4 p-6 mx-auto mt-12 rounded-xl shadow-xl w-[600px] h-auto md:w-[725px] lg:w-[800px]`}
     >
       <button
+        type="button"
         onClick={() => window.location.reload()}
         className="absolute top-5 left-5 bg-gray-200 p-2 rounded-full shadow hover:bg-gray-300"
       >

--- a/front/ui/TaskList.jsx
+++ b/front/ui/TaskList.jsx
@@ -83,6 +83,7 @@ export default function TaskList() {
       {showSidebar && selectedTask && (
         <div className="fixed inset-y-0 right-0 w-80 bg-[#1F1F1F] p-8 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out translate-x-0">
           <button
+            type="button"
             onClick={closeSidebar}
             className="text-white rounded-full p-2 hover:bg-[#333333] focus:outline-none absolute top-4 right-4"
           >
@@ -138,12 +139,14 @@ export default function TaskList() {
             </div>
 
             <button
+              type="button"
               onClick={handleUpdate}
               className="bg-[#00ADB5] text-white rounded-lg p-2 hover:bg-[#008a9e]"
             >
               更新
             </button>
             <button
+              type="button"
               onClick={async () => {
                 const taskRef = doc(db, 'tasks', selectedTask.id);
                 try {


### PR DESCRIPTION
# #112 <button> 11 箇所に type="button" を付与する

## 概要
`a11y/useButtonType` errors 11 件を解消するため、`front/` 配下 5 ファイルの clicker `<button>` に `type="button"` を機械的に付与した。本プロジェクトの `<button>` は全て non-submit のため `type="button"` で統一する (将来 `<form>` 内に submit を置く場合のみ `type="submit"` を選ぶ運用)。

## 関連Issue
close #112

## 変更内容
- [x] `app/(auth)/Auth/GoogleAuth.jsx` (Google ログイン button) に `type="button"` を付与
- [x] `app/(auth)/Auth/page.jsx` (アカウント作成 / ログイン button) 2 箇所に `type="button"` を付与
- [x] `app/Profile/page.jsx` (マトリックスに戻る / アカウントを変更 / ログアウト button) 3 箇所に `type="button"` を付与
- [x] `ui/MatrixArea.jsx` (もっと見る / リロード button) 2 箇所に `type="button"` を付与
- [x] `ui/TaskList.jsx` (close sidebar / 更新 / 削除 button) 3 箇所に `type="button"` を付与

## テスト結果
- `yarn lint:biome` の `a11y/useButtonType` errors が **11 → 0** を確認
- 振る舞い変更なし (HTML default の `type="submit"` は `<form>` 内でのみ submit 挙動になり、本プロジェクトは `<form>` を介さず `onClick` で挙動を組んでいるため `type="button"` 明示でブラウザ挙動が一致)

## チェックリスト
- [x] コーディング規約に準拠している
- [x] 必要なテストを追加した (該当なし: attribute 追加のみで振る舞い変更なし)
- [x] すべてのテストが成功している (lint で `useButtonType` 0 件確認)
- [x] ドキュメントを更新した (該当なし)
- [x] コンフリクトを解消した
