### PR TITLE
#113 TaskCard の <div onClick> を a11y 対応する

### DIFF
--- a/front/ui/TaskCard.jsx
+++ b/front/ui/TaskCard.jsx
@@ -42,8 +42,9 @@ export default function TaskCard({ task, onCheckboxChange, onCardClick }) {
   };
 
   return (
-    <div
-      className="bg-[#2B2D42] rounded-3xl shadow-md p-2 mx-2 flex items-center transform transition-transform duration-150 ease-in-out hover:scale-105"
+    <button
+      type="button"
+      className="bg-[#2B2D42] rounded-3xl shadow-md p-2 mx-2 flex items-center w-full text-left border-0 cursor-pointer transform transition-transform duration-150 ease-in-out hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
       onClick={() => onCardClick(task)}
     >
       <div className="flex items-center h-4 w-4 ml-2 rounded-full border-none">
@@ -64,6 +65,6 @@ export default function TaskCard({ task, onCheckboxChange, onCardClick }) {
           {remainingTime()}
         </p>
       </div>
-    </div>
+    </button>
   );
 }


### PR DESCRIPTION
# #113 TaskCard の <div onClick> を a11y 対応する

## 概要
`front/ui/TaskCard.jsx:45` の `<div onClick>` が biome の a11y errors を 2 件 (`a11y/noStaticElementInteractions` + `a11y/useKeyWithClickEvents`) 出していた問題を、`<button type="button">` に置換する形で解消する。@dnd-kit の drag 対象では無いことを確認済み (TaskCard / TaskList ともに @dnd-kit 未使用) のため、案 A (button 化) を採用。キーボード単独ユーザー (Tab フォーカス + Enter / Space) もタスクカードを操作できるようになる。

## 関連Issue
close #113

親 ISSUE: #110 (front の biome lint 違反 26 件を 0 errors / 0 warnings に整理する)

## 変更内容
- [x] `front/ui/TaskCard.jsx`: `<div>` を `<button type="button">` に置換 (44-67 行)
- [x] button のデフォルトスタイルを Tailwind 標準 class でリセット (`text-left` / `border-0` / `cursor-pointer` / `w-full`) し、見た目を従来通り維持
- [x] キーボードフォーカス時の視認性のため `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400` を追加
- [x] `onClick={() => onCardClick(task)}` はそのまま (Enter / Space はネイティブ button として自動発火)

## テスト結果
- `cd front && yarn run -T biome lint ui/TaskCard.jsx` → **0 errors / 0 warnings** (修正前: 2 errors)
- `front` 全体での `noStaticElementInteractions` / `useKeyWithClickEvents` 残数: **0 件**

手動確認 (レビュー時お願いします):
- [ ] `yarn dev` でタスクカードを **マウスクリック** → 従来通り `onCardClick` が発火
- [ ] タスクカードに **Tab キーでフォーカス** が当たり、focus ring が表示される
- [ ] フォーカス状態で **Enter または Space** を押すと `onCardClick` と同じ処理が走る
- [ ] チェックボックスのクリックは `e.stopPropagation()` でカード全体クリックに伝播しない (従来通り)

## チェックリスト
- [x] コーディング規約に準拠している (Tailwind 任意値新規追加なし、追加クラスはすべて標準)
- [x] 必要なテストを追加した (該当なし: TaskCard は条件分岐ロジックを含むがそれは別 ISSUE スコープ。本 PR は a11y 属性追加のみ)
- [x] すべてのテストが成功している (lint clean を確認)
- [x] ドキュメントを更新した (該当なし)
- [x] コンフリクトを解消した (origin/main 起点で切ったブランチ)

## 備考
- 本 PR はスコープを ISSUE #113 (a11y 2 件解消) に限定。`default export` 禁止 / `bg-[#2B2D42]` 等の任意値リファクタは別 ISSUE で対応。
- 親 ISSUE #110 の残タスクは #111 / #112 が完了済み、本 PR で #113 が完了する見込み。
