### PR TITLE
#119 biome.json の files.includes に .next/ 除外を追加して yarn lint:biome を実用化する

### DIFF
--- a/front/biome.json
+++ b/front/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+    "includes": [
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.ts",
+      "**/*.tsx",
+      "!.next/**",
+      "!node_modules/**"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
# #119 biome.json の files.includes に .next/ 除外を追加して yarn lint:biome を実用化する

## 概要
`front/biome.json` の `files.includes` に `.next/` と `node_modules/` の除外パターンを追加し、`yarn build` 後でも `yarn lint:biome` が 0 errors / 0 warnings で終了するようにする。`vcs.useIgnoreFile: false` のため `.gitignore` を参照しない構成のもとで、build artifacts を明示除外することで全体 lint をローカルで実用化する。

## 関連Issue
close #119

## 変更内容
- [x] `front/biome.json` の `files.includes` に `"!.next/**"` と `"!node_modules/**"` を追加 (biome 2.x の否定パターン構文)

## テスト結果
| 観点 | before | after | 判定 |
|---|---|---|---|
| ソース対象 (`app components features lib ui styles`) | 21 files / 0 errors / 0 warnings | 21 files / 0 errors / 0 warnings | カバレッジ不変 |
| 全体 (`yarn lint:biome`) — `.next/` 生成済 | 23,811 errors / 25,382 warnings | **26 files / 0 errors / 0 warnings** | 実用化 |

増加分の 5 ファイルは top-level config (`tailwind.config.js` / `next.config.js` / `postcss.config.js` / `next-env.d.ts` 等) で、元々 `**/*.{js,jsx,ts,tsx}` の対象だったが `.next/` のノイズに埋もれていたもの。

PostToolUse hook は編集ファイル単体に対して `yarn run -T biome lint "$F"` を実行する設計のため、`includes` パターンの変更とは独立で regression 要因なし。

## チェックリスト
- [x] コーディング規約に準拠している
- [x] 必要なテストを追加した (該当なし — 設定変更のため)
- [x] すべてのテストが成功している (`yarn lint:biome` で 0 errors / 0 warnings 確認)
- [x] ドキュメントを更新した (該当なし)
- [x] コンフリクトを解消した
